### PR TITLE
feat: 購入品編集機能をダイアログからページに切り出す

### DIFF
--- a/app/(authenticated)/_components/ClientForm.tsx
+++ b/app/(authenticated)/_components/ClientForm.tsx
@@ -285,7 +285,7 @@ const ClientForm = ({ initialPurchasers }: ClientFormProps) => {
 																		!inputValue ||
 																		Number.isNaN(inputValueAsNumber)
 																	)
-																		field.onChange(e);
+																		field.onChange(inputValue);
 																	else field.onChange(inputValueAsNumber);
 																}}
 																placeholder="0"

--- a/app/(authenticated)/purchase/[id]/edit/PurchaseEditForm.tsx
+++ b/app/(authenticated)/purchase/[id]/edit/PurchaseEditForm.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import usePurchaseForm from "@/app/(authenticated)/_hooks/usePurchaseForm";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { format } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type PurchaseEditFormProps = {
+	purchaseId: number;
+	initialPurchasers: Parameters<typeof usePurchaseForm>[0];
+	initialPurchase: Parameters<typeof usePurchaseForm>[2];
+};
+
+const PurchaseEditForm = ({
+	purchaseId,
+	initialPurchasers,
+	initialPurchase,
+}: PurchaseEditFormProps) => {
+	const router = useRouter();
+	const [dateInputPopoverIsOpen, setDateInputPopoverIsOpen] = useState(false);
+	const [equallyDivideCheckIsChecked, setEquallyDivideCheckIsChecked] =
+		useState(false);
+
+	const {
+		calculateDistributeRemainderRandomly,
+		form,
+		handleSubmitUpdate,
+		purchaserNames,
+		purchasersAmountPaidFields,
+		purchasersAmountToPayFields,
+		watchedPurchasersAmountPaid,
+		purchasersAmountPaidSum,
+	} = usePurchaseForm(initialPurchasers, purchaseId, initialPurchase, () =>
+		router.push("/unsettled"),
+	);
+
+	return (
+		<Form {...form}>
+			<form
+				onSubmit={form.handleSubmit(handleSubmitUpdate)}
+				className="space-y-8"
+			>
+				<FormField
+					control={form.control}
+					name="title"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>購入品名</FormLabel>
+							<FormControl>
+								<Input {...field} />
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="date"
+					render={({ field }) => (
+						<FormItem className="flex flex-col">
+							<FormLabel>購入日</FormLabel>
+							<Popover
+								open={dateInputPopoverIsOpen}
+								onOpenChange={setDateInputPopoverIsOpen}
+							>
+								<PopoverTrigger asChild>
+									<FormControl>
+										<Button
+											variant={"outline"}
+											className={cn(
+												"w-[240px] pl-3 text-left font-normal",
+												!field.value && "text-muted-foreground",
+											)}
+										>
+											{field.value ? (
+												format(field.value, "PPP")
+											) : (
+												<span>Pick a date</span>
+											)}
+											<CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+										</Button>
+									</FormControl>
+								</PopoverTrigger>
+								<PopoverContent className="w-auto p-0" align="start">
+									<Calendar
+										mode="single"
+										selected={field.value}
+										onSelect={(date) => {
+											field.onChange(date);
+											setDateInputPopoverIsOpen(false);
+										}}
+										required
+										disabled={(date) =>
+											date > new Date() || date < new Date("1900-01-01")
+										}
+										initialFocus
+									/>
+								</PopoverContent>
+							</Popover>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="note"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>メモ</FormLabel>
+							<FormControl>
+								<Input {...field} />
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				{purchaserNames.status === "error" ? (
+					<p>error</p>
+				) : (
+					<>
+						<Card>
+							<CardHeader>
+								<CardTitle>支払額</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<ul>
+									{purchasersAmountPaidFields.map((item, index) => (
+										<li key={item.id}>
+											<FormField
+												control={form.control}
+												name={`purchasersAmountPaid.${index}.amountPaid`}
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>{purchaserNames.data[index]}</FormLabel>
+														<FormControl>
+															<Input
+																{...field}
+																onChange={(e) => {
+																	const inputValue = e.target.value;
+																	const inputValueAsNumber = Number(inputValue);
+																	if (
+																		!inputValue ||
+																		Number.isNaN(inputValueAsNumber)
+																	)
+																		field.onChange(inputValue);
+																	else field.onChange(inputValueAsNumber);
+
+																	if (!equallyDivideCheckIsChecked) return;
+
+																	const amountPaidSum =
+																		watchedPurchasersAmountPaid.reduce(
+																			(
+																				accumulator,
+																				currentValue,
+																				currentIndex,
+																			) => {
+																				if (currentIndex === index)
+																					return (
+																						accumulator +
+																						Number(e.target.value ?? 0)
+																					);
+																				return (
+																					accumulator +
+																					Number(currentValue.amountPaid ?? 0)
+																				);
+																			},
+																			0,
+																		);
+
+																	calculateDistributeRemainderRandomly(
+																		amountPaidSum,
+																	);
+																}}
+																placeholder="0"
+																inputMode="numeric"
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										</li>
+									))}
+								</ul>
+							</CardContent>
+						</Card>
+
+						<Card>
+							<CardHeader>
+								<CardTitle>割勘金額</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<Switch
+									id="equallyDivideCheck"
+									onCheckedChange={() => {
+										setEquallyDivideCheckIsChecked((prev) => !prev);
+
+										if (equallyDivideCheckIsChecked) return;
+
+										const amountPaidSum = watchedPurchasersAmountPaid.reduce(
+											(accumulator, currentValue) => {
+												return (
+													accumulator + Number(currentValue.amountPaid ?? 0)
+												);
+											},
+											0,
+										);
+
+										calculateDistributeRemainderRandomly(amountPaidSum);
+									}}
+									checked={equallyDivideCheckIsChecked}
+								/>
+								<Label htmlFor="equallyDivideCheck">等分</Label>
+
+								<ul>
+									{purchasersAmountToPayFields.map((item, index) => (
+										<li key={item.id} className="py-4">
+											<FormField
+												control={form.control}
+												name={`purchasersAmountToPay.${index}.amountToPay`}
+												render={({ field }) => (
+													<FormItem>
+														<div className="flex items-center justify-between">
+															<FormLabel>
+																{purchaserNames.data[index]}
+															</FormLabel>
+															<Button
+																type="button"
+																className="h-8"
+																variant="outline"
+																onClick={() => {
+																	const otherPurchaserAmountToPays = form
+																		.getValues()
+																		.purchasersAmountToPay.reduce(
+																			(
+																				accumulator,
+																				currentValue,
+																				currentIndex,
+																			) => {
+																				if (currentIndex === index)
+																					return accumulator;
+																				return (
+																					accumulator +
+																					(typeof currentValue.amountToPay ===
+																					"number"
+																						? currentValue.amountToPay
+																						: 0)
+																				);
+																			},
+																			0,
+																		);
+																	field.onChange(
+																		purchasersAmountPaidSum -
+																			otherPurchaserAmountToPays,
+																	);
+																}}
+															>
+																残りを自動入力
+															</Button>
+														</div>
+														<FormControl>
+															<Input
+																{...field}
+																onChange={(e) => {
+																	const inputValue = e.target.value;
+																	const inputValueAsNumber = Number(inputValue);
+																	if (
+																		!inputValue ||
+																		Number.isNaN(inputValueAsNumber)
+																	)
+																		field.onChange(e);
+																	else field.onChange(inputValueAsNumber);
+																}}
+																placeholder="0"
+																inputMode="numeric"
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										</li>
+									))}
+								</ul>
+							</CardContent>
+						</Card>
+					</>
+				)}
+				<Button type="submit">更新</Button>
+			</form>
+		</Form>
+	);
+};
+
+export default PurchaseEditForm;

--- a/app/(authenticated)/purchase/[id]/edit/PurchaseEditForm.tsx
+++ b/app/(authenticated)/purchase/[id]/edit/PurchaseEditForm.tsx
@@ -292,7 +292,7 @@ const PurchaseEditForm = ({
 																		!inputValue ||
 																		Number.isNaN(inputValueAsNumber)
 																	)
-																		field.onChange(e);
+																		field.onChange(inputValue);
 																	else field.onChange(inputValueAsNumber);
 																}}
 																placeholder="0"

--- a/app/(authenticated)/purchase/[id]/edit/page.tsx
+++ b/app/(authenticated)/purchase/[id]/edit/page.tsx
@@ -1,0 +1,73 @@
+import { createClient } from "@/utils/supabase/server";
+import { notFound } from "next/navigation";
+import PurchaseEditForm from "./PurchaseEditForm";
+
+type PurchaseEditPageProps = {
+	params: {
+		id: string;
+	};
+};
+
+const PurchaseEditPage = async ({ params }: PurchaseEditPageProps) => {
+	const supabase = createClient();
+	const purchaseId = Number(params.id);
+
+	if (Number.isNaN(purchaseId)) {
+		notFound();
+	}
+
+	const { data: purchaseData, error: purchaseError } = await supabase
+		.from("purchases")
+		.select(
+			`
+      title,
+      purchase_date,
+      note,
+      purchasers_purchases ( id, purchaser_id, amount_paid, amount_to_pay )
+    `,
+		)
+		.eq("id", purchaseId)
+		.single();
+
+	if (purchaseError || !purchaseData) {
+		notFound();
+	}
+
+	const { data: purchasers, error: purchasersError } = await supabase
+		.from("purchasers")
+		.select("id, name")
+		.order("created_at", { ascending: true });
+
+	if (purchasersError) {
+		// TODO: エラーハンドリング
+		console.error(purchasersError);
+		return <p>Error</p>;
+	}
+
+	const initialPurchase = {
+		title: purchaseData.title,
+		date: purchaseData.purchase_date
+			? new Date(purchaseData.purchase_date)
+			: undefined,
+		note: purchaseData.note,
+		purchasersAmountPaid: purchaseData.purchasers_purchases.map((p) => ({
+			amountPaid: p.amount_paid ?? 0,
+		})),
+		purchasersAmountToPay: purchaseData.purchasers_purchases.map((p) => ({
+			amountToPay: p.amount_to_pay ?? 0,
+		})),
+	};
+
+	return (
+		<div className="p-4">
+			<h1 className="text-2xl font-bold mb-4">購入品編集ページ</h1>
+			<PurchaseEditForm
+				purchaseId={purchaseId}
+				initialPurchasers={purchasers}
+				initialPurchase={initialPurchase}
+			/>
+		</div>
+	);
+};
+
+export default PurchaseEditPage;

--- a/app/(authenticated)/settled/_components/ClientControlMenu.tsx
+++ b/app/(authenticated)/settled/_components/ClientControlMenu.tsx
@@ -1,78 +1,23 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-	Dialog,
-	DialogClose,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
-import { Switch } from "@/components/ui/switch";
-import { cn } from "@/lib/utils";
 import { createClient } from "@/utils/supabase/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
-import { CalendarIcon, Ellipsis } from "lucide-react";
-import { useState } from "react";
-import usePurchaseForm from "../../_hooks/usePurchaseForm";
+import { Ellipsis } from "lucide-react";
+import Link from "next/link";
 
 type ClientControlMenuProps = {
-	initialPurchasers: Parameters<typeof usePurchaseForm>[0];
-	purchaseId: Parameters<typeof usePurchaseForm>[1];
-	purchase: Parameters<typeof usePurchaseForm>[2];
+	purchaseId: number;
 };
-const ClientControlMenu = ({
-	initialPurchasers,
-	purchaseId,
-	purchase,
-}: ClientControlMenuProps) => {
+
+const ClientControlMenu = ({ purchaseId }: ClientControlMenuProps) => {
 	const supabase = createClient();
 	const queryClient = useQueryClient();
-
-	const [dialogIsOpen, setDialogIsOpen] = useState(false);
-	const [dateInputPopoverIsOpen, setDateInputPopoverIsOpen] = useState(false);
-
-	const {
-		calculateDistributeRemainderRandomly,
-		form,
-		handleSubmitUpdate,
-		purchaserNames,
-		purchasersAmountPaidFields,
-		purchasersAmountToPayFields,
-		watchedPurchasersAmountPaid,
-		purchasersAmountPaidSum,
-	} = usePurchaseForm(initialPurchasers, purchaseId, purchase, () => {
-		setDialogIsOpen(false);
-	});
-
-	const [equallyDivideCheckIsChecked, setEquallyDivideCheckIsChecked] =
-		useState(false);
 
 	const deletePurchaseMutation = useMutation({
 		mutationFn: async (purchaseId: number) => {
@@ -101,323 +46,28 @@ const ClientControlMenu = ({
 	});
 
 	return (
-		<Dialog open={dialogIsOpen} onOpenChange={setDialogIsOpen}>
-			<DropdownMenu>
-				<DropdownMenuTrigger>
-					<Ellipsis />
-				</DropdownMenuTrigger>
-				<DropdownMenuContent>
-					<DropdownMenuItem
-						className="h-12"
-						onClick={() =>
-							purchaseId && unsettlePurchaseMutation.mutate(purchaseId)
-						}
-					>
-						未精算
-					</DropdownMenuItem>
-					<DialogTrigger onClick={() => setDialogIsOpen(true)} asChild>
-						<DropdownMenuItem className="h-12">編集</DropdownMenuItem>
-					</DialogTrigger>
-					<DropdownMenuItem
-						className="h-12"
-						onClick={() =>
-							purchaseId && deletePurchaseMutation.mutate(purchaseId)
-						}
-					>
-						削除
-					</DropdownMenuItem>
-				</DropdownMenuContent>
-			</DropdownMenu>
-			<DialogContent>
-				<DialogHeader>
-					<DialogTitle>購入品情報編集</DialogTitle>
-				</DialogHeader>
-				<div className="overflow-auto h-96 px-1">
-					<Form {...form}>
-						<form
-							id="purchaseUpdateForm"
-							onSubmit={form.handleSubmit(handleSubmitUpdate)}
-							className="space-y-8"
-						>
-							<FormField
-								control={form.control}
-								name="title"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>購入品名</FormLabel>
-										<FormControl>
-											<Input {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<FormField
-								control={form.control}
-								name="date"
-								render={({ field }) => (
-									<FormItem className="flex flex-col">
-										<FormLabel>購入日</FormLabel>
-										<Popover
-											open={dateInputPopoverIsOpen}
-											onOpenChange={setDateInputPopoverIsOpen}
-										>
-											<PopoverTrigger asChild>
-												<FormControl>
-													<Button
-														variant={"outline"}
-														className={cn(
-															"w-[240px] pl-3 text-left font-normal",
-															!field.value && "text-muted-foreground",
-														)}
-													>
-														{field.value ? (
-															format(field.value, "PPP")
-														) : (
-															<span>Pick a date</span>
-														)}
-														<CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-													</Button>
-												</FormControl>
-											</PopoverTrigger>
-											<PopoverContent className="w-auto p-0" align="start">
-												<Calendar
-													mode="single"
-													selected={field.value}
-													onSelect={(date) => {
-														field.onChange(date);
-														setDateInputPopoverIsOpen(false);
-													}}
-													required
-													disabled={(date) =>
-														date > new Date() || date < new Date("1900-01-01")
-													}
-													initialFocus
-												/>
-											</PopoverContent>
-										</Popover>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<FormField
-								control={form.control}
-								name="note"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>メモ</FormLabel>
-										<FormControl>
-											<Input {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							{purchaserNames.status === "error" ? (
-								<p>error</p>
-							) : (
-								<>
-									<Card>
-										<CardHeader>
-											<CardTitle>支払額</CardTitle>
-										</CardHeader>
-										<CardContent>
-											<ul>
-												{purchasersAmountPaidFields.map((item, index) => (
-													<li key={item.id}>
-														<FormField
-															control={form.control}
-															name={`purchasersAmountPaid.${index}.amountPaid`}
-															render={({ field }) => (
-																<FormItem>
-																	<FormLabel>
-																		{purchaserNames.data[index]}
-																	</FormLabel>
-																	<FormControl>
-																		<Input
-																			{...field}
-																			onChange={(e) => {
-																				const inputValue = e.target.value;
-																				const inputValueAsNumber =
-																					Number(inputValue);
-																				if (
-																					!inputValue ||
-																					Number.isNaN(inputValueAsNumber)
-																				)
-																					field.onChange(inputValue);
-																				else field.onChange(inputValueAsNumber);
-
-																				if (!equallyDivideCheckIsChecked)
-																					return;
-
-																				const amountPaidSum =
-																					watchedPurchasersAmountPaid.reduce(
-																						(
-																							accumulator,
-																							currentValue,
-																							currentIndex,
-																						) => {
-																							if (currentIndex === index)
-																								return (
-																									accumulator +
-																									Number(e.target.value ?? 0)
-																								);
-																							return (
-																								accumulator +
-																								Number(
-																									currentValue.amountPaid ?? 0,
-																								)
-																							);
-																						},
-																						0,
-																					);
-
-																				calculateDistributeRemainderRandomly(
-																					amountPaidSum,
-																				);
-																			}}
-																			placeholder="0"
-																			inputMode="numeric"
-																		/>
-																	</FormControl>
-																	<FormMessage />
-																</FormItem>
-															)}
-														/>
-													</li>
-												))}
-											</ul>
-										</CardContent>
-									</Card>
-
-									<Card>
-										<CardHeader>
-											<CardTitle>割勘金額</CardTitle>
-										</CardHeader>
-										<CardContent>
-											<Switch
-												id="equallyDivideCheck"
-												onCheckedChange={() => {
-													setEquallyDivideCheckIsChecked((prev) => !prev);
-
-													if (equallyDivideCheckIsChecked) return;
-
-													const amountPaidSum =
-														watchedPurchasersAmountPaid.reduce(
-															(accumulator, currentValue) => {
-																return (
-																	accumulator +
-																	Number(currentValue.amountPaid ?? 0)
-																);
-															},
-															0,
-														);
-
-													calculateDistributeRemainderRandomly(amountPaidSum);
-												}}
-												checked={equallyDivideCheckIsChecked}
-											/>
-											<Label htmlFor="equallyDivideCheck">等分</Label>
-
-											<ul>
-												{purchasersAmountToPayFields.map((item, index) => (
-													<li key={item.id} className="py-4">
-														<FormField
-															control={form.control}
-															name={`purchasersAmountToPay.${index}.amountToPay`}
-															render={({ field }) => (
-																<FormItem>
-																	<div className="flex items-center justify-between">
-																		<FormLabel>
-																			{purchaserNames.data[index]}
-																		</FormLabel>
-																		<Button
-																			type="button"
-																			className="h-8"
-																			variant="outline"
-																			onClick={() => {
-																				const otherPurchaserAmountToPays = form
-																					.getValues()
-																					.purchasersAmountToPay.reduce(
-																						(
-																							accumulator,
-																							currentValue,
-																							currentIndex,
-																						) => {
-																							if (currentIndex === index)
-																								return accumulator;
-																							return (
-																								accumulator +
-																								(typeof currentValue.amountToPay ===
-																								"number"
-																									? currentValue.amountToPay
-																									: 0)
-																							);
-																						},
-																						0,
-																					);
-																				field.onChange(
-																					purchasersAmountPaidSum -
-																						otherPurchaserAmountToPays,
-																				);
-																			}}
-																		>
-																			残りを自動入力
-																		</Button>
-																	</div>
-																	<FormControl>
-																		<Input
-																			{...field}
-																			onChange={(e) => {
-																				const inputValue = e.target.value;
-																				const inputValueAsNumber =
-																					Number(inputValue);
-																				if (
-																					!inputValue ||
-																					Number.isNaN(inputValueAsNumber)
-																				)
-																					field.onChange(e);
-																				else field.onChange(inputValueAsNumber);
-																			}}
-																			placeholder="0"
-																			inputMode="numeric"
-																		/>
-																	</FormControl>
-																	<FormMessage />
-																</FormItem>
-															)}
-														/>
-													</li>
-												))}
-											</ul>
-										</CardContent>
-									</Card>
-								</>
-							)}
-						</form>
-					</Form>
-				</div>
-				<DialogFooter>
-					<Button type="submit" form="purchaseUpdateForm">
-						OK
-					</Button>
-					<DialogClose asChild>
-						<Button
-							type="button"
-							onClick={() => {
-								form.reset();
-								setDialogIsOpen(false);
-							}}
-						>
-							キャンセル
-						</Button>
-					</DialogClose>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+		<DropdownMenu>
+			<DropdownMenuTrigger>
+				<Ellipsis />
+			</DropdownMenuTrigger>
+			<DropdownMenuContent>
+				<DropdownMenuItem
+					className="h-12"
+					onClick={() => unsettlePurchaseMutation.mutate(purchaseId)}
+				>
+					未精算
+				</DropdownMenuItem>
+				<Link href={`/purchase/${purchaseId}/edit`}>
+					<DropdownMenuItem className="h-12">編集</DropdownMenuItem>
+				</Link>
+				<DropdownMenuItem
+					className="h-12"
+					onClick={() => deletePurchaseMutation.mutate(purchaseId)}
+				>
+					削除
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 };
 export default ClientControlMenu;

--- a/app/(authenticated)/settled/_components/ClientSettledTable.tsx
+++ b/app/(authenticated)/settled/_components/ClientSettledTable.tsx
@@ -155,21 +155,7 @@ const ClientSettledTable = ({
 								<TableCell>{purchase.date}</TableCell>
 								<TableCell>{purchase.totalAmount}</TableCell>
 								<TableCell>
-									<ClientControlMenu
-										initialPurchasers={initialPurchasers}
-										purchaseId={purchase.id}
-										purchase={{
-											title: purchase.title,
-											date: purchase.date ? new Date(purchase.date) : undefined,
-											note: purchase.note,
-											purchasersAmountPaid: purchase.purchasers.map((x) => ({
-												amountPaid: x.amount_paid ?? 0,
-											})),
-											purchasersAmountToPay: purchase.purchasers.map((x) => ({
-												amountToPay: x.amount_to_pay ?? 0,
-											})),
-										}}
-									/>
+									<ClientControlMenu purchaseId={purchase.id} />
 								</TableCell>
 							</TableRow>
 						))}

--- a/app/(authenticated)/unsettled/_components/ClientControlMenu.tsx
+++ b/app/(authenticated)/unsettled/_components/ClientControlMenu.tsx
@@ -1,79 +1,23 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-	Dialog,
-	DialogClose,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
-import { Switch } from "@/components/ui/switch";
-import { cn } from "@/lib/utils";
 import { createClient } from "@/utils/supabase/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
-import { CalendarIcon, Ellipsis } from "lucide-react";
-import { useState } from "react";
-import usePurchaseForm from "../../_hooks/usePurchaseForm";
+import { Ellipsis } from "lucide-react";
+import Link from "next/link";
 
 type ClientControlMenuProps = {
-	initialPurchasers: Parameters<typeof usePurchaseForm>[0];
-	purchaseId: Parameters<typeof usePurchaseForm>[1];
-	purchase: Parameters<typeof usePurchaseForm>[2];
+	purchaseId: number;
 };
-// ドロップダウンメニューごとダイアログ化する必要あり(参考→https://ui.shadcn.com/docs/components/dialog)
-const ClientControlMenu = ({
-	initialPurchasers,
-	purchaseId,
-	purchase,
-}: ClientControlMenuProps) => {
+
+const ClientControlMenu = ({ purchaseId }: ClientControlMenuProps) => {
 	const supabase = createClient();
 	const queryClient = useQueryClient();
-
-	const [dialogIsOpen, setDialogIsOpen] = useState(false);
-	const [dateInputPopoverIsOpen, setDateInputPopoverIsOpen] = useState(false);
-
-	const {
-		calculateDistributeRemainderRandomly,
-		form,
-		handleSubmitUpdate,
-		purchaserNames,
-		purchasersAmountPaidFields,
-		purchasersAmountToPayFields,
-		watchedPurchasersAmountPaid,
-		purchasersAmountPaidSum,
-	} = usePurchaseForm(initialPurchasers, purchaseId, purchase, () => {
-		setDialogIsOpen(false);
-	});
-
-	const [equallyDivideCheckIsChecked, setEquallyDivideCheckIsChecked] =
-		useState(false);
 
 	const deletePurchaseMutation = useMutation({
 		mutationFn: async (purchaseId: number) => {
@@ -102,323 +46,28 @@ const ClientControlMenu = ({
 	});
 
 	return (
-		<Dialog open={dialogIsOpen} onOpenChange={setDialogIsOpen}>
-			<DropdownMenu>
-				<DropdownMenuTrigger>
-					<Ellipsis />
-				</DropdownMenuTrigger>
-				<DropdownMenuContent>
-					<DropdownMenuItem
-						className="h-12"
-						onClick={() =>
-							purchaseId && settlePurchaseMutation.mutate(purchaseId)
-						}
-					>
-						精算
-					</DropdownMenuItem>
-					<DialogTrigger onClick={() => setDialogIsOpen(true)} asChild>
-						<DropdownMenuItem className="h-12">編集</DropdownMenuItem>
-					</DialogTrigger>
-					<DropdownMenuItem
-						className="h-12"
-						onClick={() =>
-							purchaseId && deletePurchaseMutation.mutate(purchaseId)
-						}
-					>
-						削除
-					</DropdownMenuItem>
-				</DropdownMenuContent>
-			</DropdownMenu>
-			<DialogContent>
-				<DialogHeader>
-					<DialogTitle>購入品情報編集</DialogTitle>
-				</DialogHeader>
-				<div className="overflow-auto h-96 px-1">
-					<Form {...form}>
-						<form
-							id="purchaseUpdateForm"
-							onSubmit={form.handleSubmit(handleSubmitUpdate)}
-							className="space-y-8"
-						>
-							<FormField
-								control={form.control}
-								name="title"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>購入品名</FormLabel>
-										<FormControl>
-											<Input {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<FormField
-								control={form.control}
-								name="date"
-								render={({ field }) => (
-									<FormItem className="flex flex-col">
-										<FormLabel>購入日</FormLabel>
-										<Popover
-											open={dateInputPopoverIsOpen}
-											onOpenChange={setDateInputPopoverIsOpen}
-										>
-											<PopoverTrigger asChild>
-												<FormControl>
-													<Button
-														variant={"outline"}
-														className={cn(
-															"w-[240px] pl-3 text-left font-normal",
-															!field.value && "text-muted-foreground",
-														)}
-													>
-														{field.value ? (
-															format(field.value, "PPP")
-														) : (
-															<span>Pick a date</span>
-														)}
-														<CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-													</Button>
-												</FormControl>
-											</PopoverTrigger>
-											<PopoverContent className="w-auto p-0" align="start">
-												<Calendar
-													mode="single"
-													selected={field.value}
-													onSelect={(date) => {
-														field.onChange(date);
-														setDateInputPopoverIsOpen(false);
-													}}
-													required
-													disabled={(date) =>
-														date > new Date() || date < new Date("1900-01-01")
-													}
-													initialFocus
-												/>
-											</PopoverContent>
-										</Popover>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<FormField
-								control={form.control}
-								name="note"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>メモ</FormLabel>
-										<FormControl>
-											<Input {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							{purchaserNames.status === "error" ? (
-								<p>error</p>
-							) : (
-								<>
-									<Card>
-										<CardHeader>
-											<CardTitle>支払額</CardTitle>
-										</CardHeader>
-										<CardContent>
-											<ul>
-												{purchasersAmountPaidFields.map((item, index) => (
-													<li key={item.id}>
-														<FormField
-															control={form.control}
-															name={`purchasersAmountPaid.${index}.amountPaid`}
-															render={({ field }) => (
-																<FormItem>
-																	<FormLabel>
-																		{purchaserNames.data[index]}
-																	</FormLabel>
-																	<FormControl>
-																		<Input
-																			{...field}
-																			onChange={(e) => {
-																				const inputValue = e.target.value;
-																				const inputValueAsNumber =
-																					Number(inputValue);
-																				if (
-																					!inputValue ||
-																					Number.isNaN(inputValueAsNumber)
-																				)
-																					field.onChange(inputValue);
-																				else field.onChange(inputValueAsNumber);
-
-																				if (!equallyDivideCheckIsChecked)
-																					return;
-
-																				const amountPaidSum =
-																					watchedPurchasersAmountPaid.reduce(
-																						(
-																							accumulator,
-																							currentValue,
-																							currentIndex,
-																						) => {
-																							if (currentIndex === index)
-																								return (
-																									accumulator +
-																									Number(e.target.value ?? 0)
-																								);
-																							return (
-																								accumulator +
-																								Number(
-																									currentValue.amountPaid ?? 0,
-																								)
-																							);
-																						},
-																						0,
-																					);
-
-																				calculateDistributeRemainderRandomly(
-																					amountPaidSum,
-																				);
-																			}}
-																			placeholder="0"
-																			inputMode="numeric"
-																		/>
-																	</FormControl>
-																	<FormMessage />
-																</FormItem>
-															)}
-														/>
-													</li>
-												))}
-											</ul>
-										</CardContent>
-									</Card>
-
-									<Card>
-										<CardHeader>
-											<CardTitle>割勘金額</CardTitle>
-										</CardHeader>
-										<CardContent>
-											<Switch
-												id="equallyDivideCheck"
-												onCheckedChange={() => {
-													setEquallyDivideCheckIsChecked((prev) => !prev);
-
-													if (equallyDivideCheckIsChecked) return;
-
-													const amountPaidSum =
-														watchedPurchasersAmountPaid.reduce(
-															(accumulator, currentValue) => {
-																return (
-																	accumulator +
-																	Number(currentValue.amountPaid ?? 0)
-																);
-															},
-															0,
-														);
-
-													calculateDistributeRemainderRandomly(amountPaidSum);
-												}}
-												checked={equallyDivideCheckIsChecked}
-											/>
-											<Label htmlFor="equallyDivideCheck">等分</Label>
-
-											<ul>
-												{purchasersAmountToPayFields.map((item, index) => (
-													<li key={item.id} className="py-4">
-														<FormField
-															control={form.control}
-															name={`purchasersAmountToPay.${index}.amountToPay`}
-															render={({ field }) => (
-																<FormItem>
-																	<div className="flex items-center justify-between">
-																		<FormLabel>
-																			{purchaserNames.data[index]}
-																		</FormLabel>
-																		<Button
-																			type="button"
-																			className="h-8"
-																			variant="outline"
-																			onClick={() => {
-																				const otherPurchaserAmountToPays = form
-																					.getValues()
-																					.purchasersAmountToPay.reduce(
-																						(
-																							accumulator,
-																							currentValue,
-																							currentIndex,
-																						) => {
-																							if (currentIndex === index)
-																								return accumulator;
-																							return (
-																								accumulator +
-																								(typeof currentValue.amountToPay ===
-																								"number"
-																									? currentValue.amountToPay
-																									: 0)
-																							);
-																						},
-																						0,
-																					);
-																				field.onChange(
-																					purchasersAmountPaidSum -
-																						otherPurchaserAmountToPays,
-																				);
-																			}}
-																		>
-																			残りを自動入力
-																		</Button>
-																	</div>
-																	<FormControl>
-																		<Input
-																			{...field}
-																			onChange={(e) => {
-																				const inputValue = e.target.value;
-																				const inputValueAsNumber =
-																					Number(inputValue);
-																				if (
-																					!inputValue ||
-																					Number.isNaN(inputValueAsNumber)
-																				)
-																					field.onChange(e);
-																				else field.onChange(inputValueAsNumber);
-																			}}
-																			placeholder="0"
-																			inputMode="numeric"
-																		/>
-																	</FormControl>
-																	<FormMessage />
-																</FormItem>
-															)}
-														/>
-													</li>
-												))}
-											</ul>
-										</CardContent>
-									</Card>
-								</>
-							)}
-						</form>
-					</Form>
-				</div>
-				<DialogFooter>
-					<Button type="submit" form="purchaseUpdateForm">
-						OK
-					</Button>
-					<DialogClose asChild>
-						<Button
-							type="button"
-							onClick={() => {
-								form.reset();
-								setDialogIsOpen(false);
-							}}
-						>
-							キャンセル
-						</Button>
-					</DialogClose>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+		<DropdownMenu>
+			<DropdownMenuTrigger>
+				<Ellipsis />
+			</DropdownMenuTrigger>
+			<DropdownMenuContent>
+				<DropdownMenuItem
+					className="h-12"
+					onClick={() => settlePurchaseMutation.mutate(purchaseId)}
+				>
+					精算
+				</DropdownMenuItem>
+				<Link href={`/purchase/${purchaseId}/edit`}>
+					<DropdownMenuItem className="h-12">編集</DropdownMenuItem>
+				</Link>
+				<DropdownMenuItem
+					className="h-12"
+					onClick={() => deletePurchaseMutation.mutate(purchaseId)}
+				>
+					削除
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 };
 export default ClientControlMenu;

--- a/app/(authenticated)/unsettled/_components/ClientUnsettledTable.tsx
+++ b/app/(authenticated)/unsettled/_components/ClientUnsettledTable.tsx
@@ -204,23 +204,7 @@ const ClientUnsettledTable = ({
 									<TableCell>{purchase.date}</TableCell>
 									<TableCell>{purchase.totalAmount}</TableCell>
 									<TableCell>
-										<ClientControlMenu
-											initialPurchasers={initialPurchasers}
-											purchaseId={purchase.id}
-											purchase={{
-												title: purchase.title,
-												date: purchase.date
-													? new Date(purchase.date)
-													: undefined,
-												note: purchase.note,
-												purchasersAmountPaid: purchase.purchasers.map((x) => ({
-													amountPaid: x.amount_paid ?? 0,
-												})),
-												purchasersAmountToPay: purchase.purchasers.map((x) => ({
-													amountToPay: x.amount_to_pay ?? 0,
-												})),
-											}}
-										/>
+										<ClientControlMenu purchaseId={purchase.id} />
 									</TableCell>
 								</TableRow>
 							))}


### PR DESCRIPTION
Closes #2

## 概要

Issue #2 に基づき、購入品の編集機能をダイアログ形式から専用の編集ページ（`/purchase/[id]/edit`）に移行しました。
これにより、編集時のURLが明確になり、ユーザーエクスペリエンスが向上します。

## 主な変更点

- **購入品編集ページの作成**:
  - `/app/(authenticated)/purchase/[id]/edit/page.tsx` を新設し、購入品情報を編集するための専用ページを実装しました。
  - フォームコンポーネントとして `PurchaseEditForm.tsx` を作成し、既存の `usePurchaseForm` フックを再利用してロジックを共通化しています。

- **既存コンポーネントの修正**:
  - `ClientSettledTable` および `ClientUnsettledTable` 内の編集ボタンの挙動を変更しました。
  - これまでのダイアログ表示を廃止し、Next.jsの `Link` コンポーネントを用いて新しい編集ページへ遷移するように修正しました。
  - `ClientControlMenu` から不要になったダイアログ関連のコードとstateを削除し、コンポーネントをシンプルにしました。

## 確認方法

1. 未清算リスト（`/unsettled`）または清算��みリスト（`/settled`）に表示される購入品のメニューから「編集」を選択します。
2. `purchase/[id]/edit` のURLを持つ編集ページに遷移することを確認します。
3. フォームで値を変更し、「更新」ボタンを押すと、データが正常に更新され、未清算ページにリダイレクトされることを確認します。
